### PR TITLE
entry: dnstable_entry_to_json(): Use the DNSDB API rdata format

### DIFF
--- a/dnstable/entry.c
+++ b/dnstable/entry.c
@@ -200,7 +200,7 @@ dnstable_entry_to_json(struct dnstable_entry *e)
 			assert(rc == 0);
 		} else {
 			char buf[sizeof("TYPE65535")];
-			snprintf(buf, sizeof(buf), "TYPE%hu", e->rrtype);
+			snprintf(buf, sizeof(buf), "TYPE%hu", (uint16_t) e->rrtype);
 			json_t *j_rrtype = json_string(buf);
 			assert(j_rrtype != NULL);
 			rc = json_object_set_new(j, "rrtype", j_rrtype);


### PR DESCRIPTION
In order to make dnstable_entry_to_json() generate the same format that
the DNSDB API uses:
- Also output the count, time_first, and time_last fields for rdata
  entries.
- Format the rrtype as a mnemonic rather than a bare integer.
