### PR TITLE
Branches/reader reload setfile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ else
 fi
 
 PKG_CHECK_MODULES([libjansson], [jansson])
-PKG_CHECK_MODULES([libmtbl], [libmtbl])
+PKG_CHECK_MODULES([libmtbl], [libmtbl >= 0.8.0])
 PKG_CHECK_MODULES([libnmsg], [libnmsg])
 PKG_CHECK_MODULES([libwdns], [libwdns >= 0.6.0])
 

--- a/dnstable/dnstable.h
+++ b/dnstable/dnstable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 by Farsight Security, Inc.
+ * Copyright (c) 2012, 2014-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,9 @@ dnstable_reader_init(const struct mtbl_source *);
 
 struct dnstable_reader *
 dnstable_reader_init_setfile(const char *);
+
+void
+dnstable_reader_reload_setfile(struct dnstable_reader *);
 
 void
 dnstable_reader_destroy(struct dnstable_reader **);

--- a/dnstable/libdnstable.sym
+++ b/dnstable/libdnstable.sym
@@ -41,3 +41,8 @@ LIBDNSTABLE_0.7.0 {
 global:
         dnstable_entry_set_iszone;
 } LIBDNSTABLE_0.6.0;
+
+LIBDNSTABLE_0.8.0 {
+global:
+        dnstable_reader_reload_setfile;
+} LIBDNSTABLE_0.7.0;

--- a/dnstable/reader.c
+++ b/dnstable/reader.c
@@ -55,6 +55,13 @@ dnstable_reader_init_setfile(const char *setfile)
 }
 
 void
+dnstable_reader_reload_setfile(struct dnstable_reader *r)
+{
+	if (r->fs != NULL)
+		mtbl_fileset_reload_now(r->fs);
+}
+
+void
 dnstable_reader_destroy(struct dnstable_reader **r)
 {
 	if (*r) {

--- a/man/dnstable_reader.3.txt
+++ b/man/dnstable_reader.3.txt
@@ -18,6 +18,10 @@ dnstable_reader_init_setfile(const char *'setfile');^
 
 [verse]
 ^void
+dnstable_reader_reload_setfile(struct dnstable_reader *'r');^
+
+[verse]
+^void
 dnstable_reader_destroy(struct dnstable_reader **'r');^
 
 [verse]
@@ -46,6 +50,10 @@ interface.
 ^dnstable_reader_init^(), which takes an ^mtbl_source^ object, or by calling
 ^dnstable_reader_init_setfile^(), which takes the path to a "setfile", which is
 a text file containing a list of dnstable data file paths, one per line.
+
+^dnstable_reader_reload_setfile^() will force a reload of a ^dnstable_reader^
+object initialized by ^dnstable_reader_init_setfile^() by re-reading the
+underlying setfile.
 
 ^dnstable_reader_iter^() iterates over every entry object in the data source.
 


### PR DESCRIPTION
This commit adds a new function, dnstable_reader_reload_setfile(), which
calls mtbl_fileset_reload_now() on the underlying mtbl_fileset object,
if the dnstable_reader object has an underlying mtbl_fileset object.
I.e., the dnstable_reader object was initialized by
dnstable_reader_init_setfile().

This function is intended to be called by higher level event loops that
can, for example, place an inotify watch on the setfile's filesystem
path, so that instantaneous reloads can be performed.

(This branch currently fails its Travis-CI build, since it depends on a `libmtbl` that hasn't been released yet, and the Travis-CI build is performed with the release package from our repository. It's intended to release dnstable 0.8.0 and mtbl 0.8.0 at the same time...)