### PR TITLE
Use CLOCK_MONOTONIC_COARSE rather than CLOCK_MONOTONIC_RAW

### DIFF
--- a/dnstable/dnstable-private.h
+++ b/dnstable/dnstable-private.h
@@ -69,12 +69,12 @@
 
 /* best clock for my_gettime() */
 
-#if defined(CLOCK_MONOTONIC_RAW)
-# define DNSTABLE__CLOCK_MONOTONIC CLOCK_MONOTONIC_RAW
+#if defined(CLOCK_MONOTONIC_COARSE)
+# define DNSTABLE__CLOCK_MONOTONIC CLOCK_MONOTONIC_COARSE
 #elif defined(CLOCK_MONOTONIC)
 # define DNSTABLE__CLOCK_MONOTONIC CLOCK_MONOTONIC
 #else
-# error Neither CLOCK_MONOTONIC nor CLOCK_MONOTONIC_RAW are available.
+# error Neither CLOCK_MONOTONIC nor CLOCK_MONOTONIC_COARSE are available.
 #endif
 
 /* triplet */


### PR DESCRIPTION
Using CLOCK_MONOTONIC_RAW to detect timeouts has a noticeable impact on
the total runtime of long-running queries, because CLOCK_MONOTONIC_RAW
incurs the overhead of a system call for each clock_gettime().

Taking an 'rdata ip' query that takes a long time to run and returns no
results, because 100% of the underlying key-value entries are excluded
by the filter step, the previous dnstable release (0.8.0) runs this
query in 39.2 seconds.

The current dnstable 'next', running with timeouts disabled, runs this
query in 40.2 seconds, or 2.5% longer. This appears to be due to the
cost of the extra branch (not taken, since timeouts are disabled) in the
inner loop of query_iter_next().

Enabling timeouts, which currently cause a CLOCK_MONOTONIC_RAW fetch to
be performed in the inner loop causes the runtime to balloon to 46.6
seconds, or 19% longer. This is too large of a performance hit.

Replacing the CLOCK_MONOTONIC_RAW fetch (which requires a syscall), with
a CLOCK_MONOTONIC fetch (which only hits the vDSO) reduces the
performance hit to ~7%.

However, using CLOCK_MONOTONIC_COARSE is a little bit better; it reduces
the performance hit to only ~5%.

Probably any of CLOCK_MONOTONIC or its variants are suitable for
calculating our timeouts. We don't need ultra-precise timeouts, as in
practice fairly round timeout values are likely to be used, nor are we
particularly affected by the NTP-induced incremental adjustments that
CLOCK_MONOTONIC and CLOCK_MONOTONIC_COARSE are subject to. (These
adjustments typically only speed up or slow down the clock by a very
tiny amount.)

Note that none of these clocks consult the real (wall-clock) time and
aren't subject to discontinuous jumps.

So, replace CLOCK_MONOTONIC_RAW with CLOCK_MONOTONIC_COARSE, since it's
the best performing clock with the semantics that we need.