### PR TITLE
entry: Fixup "odd" data patterns

### DIFF
--- a/dnstable/entry.c
+++ b/dnstable/entry.c
@@ -336,10 +336,20 @@ out:
 static dnstable_res
 decode_val_triplet(struct dnstable_entry *e, const uint8_t *val, size_t len_val)
 {
-	return (triplet_unpack(val, len_val,
-			       &e->time_first,
-			       &e->time_last,
-			       &e->count));
+	dnstable_res res;
+
+	res = triplet_unpack(val, len_val, &e->time_first, &e->time_last, &e->count);
+	if (res == dnstable_res_success) {
+		/* Fixups for "odd" data patterns. */
+		if (e->count == 0) {
+			e->count = 1;
+		}
+		if (e->time_last == 0) {
+			e->time_last = e->time_first;
+		}
+	}
+
+	return (res);
 }
 
 static dnstable_res


### PR DESCRIPTION
For data triplets where count is 0, silently fix this up to 1.

For data triplets where time_last is 0 (aka 1970-01-01 00:00:00 +0000),
silently set time_last to be the same as time_first.

These data patterns sometimes accidentally occur in real-world dnstable
data, and silently fixing these patterns makes it easier on downstream
consumer, who need fewer special cases (e.g. time_last minus time_first
should never yield a negative value).