### PR TITLE
FTB on Mac: Use alternate htole16 function

### DIFF
--- a/dnstable/dnstable-private.h
+++ b/dnstable/dnstable-private.h
@@ -25,6 +25,11 @@
 # endif
 #endif
 
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#endif
+
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
dnstable does not build on mac.
```
src/dnstable_convert.c:240:10: warning: implicit declaration of function
      'htole16' is invalid in C99 [-Wimplicit-function-declaration]
        rdlen = htole16((uint16_t) dns->rdata[i].len);
                ^
src/dnstable_convert.c:240:10: warning: this function declaration is not a
      prototype [-Wstrict-prototypes]

Undefined symbols for architecture x86_64:
  "_htole16", referenced from:
      _main in dnstable_convert.o
ld: symbol(s) not found for architecture x86_64
```

This patch substitutes htole16 for the OSSwapHostToLittleInt16 function on mac.