### PR TITLE
Use #include <yajl/yajl_gen.h> subdirectory regardless of YAJL version

### DIFF
--- a/dnstable/dnstable-private.h
+++ b/dnstable/dnstable-private.h
@@ -45,11 +45,7 @@
 #include <mtbl.h>
 #include <wdns.h>
 
-#ifdef HAVE_YAJL_1
-# include <yajl/yajl_gen.h>
-#else
-# include <yajl_gen.h>
-#endif
+#include <yajl/yajl_gen.h>
 
 #include "dnstable.h"
 


### PR DESCRIPTION
YAJL 1 also installed the header  in subdirectory like that.
The YAJL documentation shows includes with yajl subdirectory.
Various packagers of yajl fix their broken pkg-config includedir.
A fix was reported to yajl https://github.com/lloyd/yajl/pull/139

(Note that even though Debian has wrong includedir too, the compile
still works because /usr/include is default.)