### PR TITLE
Bug fix: dnsdb api raw lookup with rrtype.

### DIFF
--- a/dnstable/query.c
+++ b/dnstable/query.c
@@ -974,10 +974,6 @@ query_init_rdata_raw(struct query_iter *it)
 	/* key: rdata */
 	ubuf_append(it->key, it->query->rdata, it->query->len_rdata);
 
-	/* key: rrtype */
-	if (it->query->do_rrtype)
-		add_rrtype_to_key(it->key, it->query->rrtype);
-
 	it->m_iter = mtbl_source_get_prefix(it->source, ubuf_data(it->key), ubuf_size(it->key));
 	return dnstable_iter_init(query_iter_next, query_iter_free, it);
 }

--- a/tests/tests.sh.in
+++ b/tests/tests.sh.in
@@ -105,4 +105,13 @@ test_lookup rdata name ldap.example.com << EOF
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"_ldap._tcp.example.com.","rrtype":"SRV","rdata":"10 1 389 ldap.example.com."}
 EOF
 
+test_lookup rdata raw 00 SRV << EOF
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"_ldap._tcp.example.com.","rrtype":"SRV","rdata":"10 1 389 ldap.example.com."}
+EOF
+
+test_lookup rdata raw 00 MX << EOF
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
+EOF
+
 exit $code


### PR DESCRIPTION
For rdata raw queries, do not append rrtype to the raw data.  The query will filter on rrtype on output.  Here is an example of the bug fix in action:

Using the "tests" directory's mtbl file:
`$ export DNSTABLE_FNAME=.../tests/test-dns.mtbl`
Without specifying an rrtype:
```
$ ./src/dnstable_lookup rdata raw 00 
_ldap._tcp.example.com. IN SRV 10 1 389 ldap.example.com.
example.com. IN MX 10 mail.example.com.
example.com. IN MX 20 mail2.example.com.
;;; Dumped 3 entries.
```
Using the original version of the code:
```
$ /usr/local/bin/dnstable_lookup rdata raw 00 SRV
;;; Dumped 0 entries.
```
With the bug fix:
```
$ ./src/dnstable_lookup rdata raw 00 SRV
_ldap._tcp.example.com. IN SRV 10 1 389 ldap.example.com.
;;; Dumped 1 entries.
$ ./src/dnstable_lookup rdata raw 00 MX
example.com. IN MX 10 mail.example.com.
example.com. IN MX 20 mail2.example.com.
;;; Dumped 2 entries.
```