### PR TITLE
merge_identical_use_max_count

### DIFF
--- a/dnstable/merge.c
+++ b/dnstable/merge.c
@@ -37,9 +37,17 @@ dnstable_merge_func(void *clos,
 		res = triplet_unpack(val1, len_val1, &time_first1, &time_last1, &count1);
 		assert(res == dnstable_res_success);
 
-		time_first0 = (time_first0 < time_first1) ? time_first0 : time_first1;
-		time_last0 = (time_last0 > time_last1) ? time_last0 : time_last1;
-		count0 += count1;
+                if (time_first0 == time_first1 && time_last0 == time_last1) {
+                        /* if the time pairs are identical then use the maximum count */
+                        if (count1 > count0)
+                                count0 = count1;
+                } else {
+                        /* otherwise use the earliest of the first times,
+                           the latest of the last times, and sum the counts */
+                        time_first0 = (time_first0 < time_first1) ? time_first0 : time_first1;
+                        time_last0 = (time_last0 > time_last1) ? time_last0 : time_last1;
+                        count0 += count1;
+                }
 
 		*merged_val = my_malloc(32);
 		*len_merged_val = triplet_pack(*merged_val, time_first0, time_last0, count0);

--- a/man/dnstable_merge_func.3
+++ b/man/dnstable_merge_func.3
@@ -93,6 +93,8 @@ The two
 \fBcount\fR
 values are added together\&.
 .RE
+.sp
+If the both time_firsts are equal and both time_lasts are equal then uses the maximum of the two count values.
 .SH "SEE ALSO"
 .sp
 \fBdnstable\-encoding\fR(5), \fBmtbl_merger\fR(3)


### PR DESCRIPTION
If the both time_firsts are equal and both time_lasts are equal then uses the maximum of the two count values