### PR TITLE
Add ability to skip first # rows of results with dnstable_query_set_skip() function.

### DIFF
--- a/dnstable/dnstable-private.h
+++ b/dnstable/dnstable-private.h
@@ -96,4 +96,7 @@ bytes_compare(const uint8_t *a, size_t len_a,
 	return (ret);
 }
 
+bool
+dnstable_query_is_aggregated(const struct dnstable_query *);
+
 #endif /* DNSTABLE_PRIVATE_H */

--- a/dnstable/dnstable.h
+++ b/dnstable/dnstable.h
@@ -112,6 +112,10 @@ dnstable_query_set_rrtype(struct dnstable_query *,
 			  const char *);
 
 dnstable_res
+dnstable_query_set_skip(struct dnstable_query *,
+			uint64_t);
+
+dnstable_res
 dnstable_query_set_aggregated(struct dnstable_query *, bool);
 
 dnstable_res

--- a/dnstable/dnstable.h
+++ b/dnstable/dnstable.h
@@ -112,6 +112,12 @@ dnstable_query_set_rrtype(struct dnstable_query *,
 			  const char *);
 
 dnstable_res
+dnstable_query_set_aggregated(struct dnstable_query *, bool);
+
+bool
+dnstable_query_is_aggregated(const struct dnstable_query *);
+
+dnstable_res
 dnstable_query_set_bailiwick(struct dnstable_query *,
 			     const char *);
 

--- a/dnstable/dnstable.h
+++ b/dnstable/dnstable.h
@@ -114,9 +114,6 @@ dnstable_query_set_rrtype(struct dnstable_query *,
 dnstable_res
 dnstable_query_set_aggregated(struct dnstable_query *, bool);
 
-bool
-dnstable_query_is_aggregated(const struct dnstable_query *);
-
 dnstable_res
 dnstable_query_set_bailiwick(struct dnstable_query *,
 			     const char *);

--- a/dnstable/libdnstable.sym
+++ b/dnstable/libdnstable.sym
@@ -58,4 +58,5 @@ global:
 LIBDNSTABLE_0.10.0 {
 global:
         dnstable_query_set_aggregated;
+        dnstable_query_set_skip;
 } LIBDNSTABLE_0.9.0;

--- a/dnstable/libdnstable.sym
+++ b/dnstable/libdnstable.sym
@@ -54,3 +54,9 @@ global:
         dnstable_query_set_filter_parameter;
         dnstable_query_set_timeout;
 } LIBDNSTABLE_0.8.0;
+
+LIBDNSTABLE_0.10.0 {
+global:
+        dnstable_query_set_aggregated;
+        dnstable_query_is_aggregated;
+} LIBDNSTABLE_0.9.0;

--- a/dnstable/libdnstable.sym
+++ b/dnstable/libdnstable.sym
@@ -58,5 +58,4 @@ global:
 LIBDNSTABLE_0.10.0 {
 global:
         dnstable_query_set_aggregated;
-        dnstable_query_is_aggregated;
 } LIBDNSTABLE_0.9.0;

--- a/dnstable/query.c
+++ b/dnstable/query.c
@@ -974,10 +974,6 @@ query_init_rdata_raw(struct query_iter *it)
 	/* key: rdata */
 	ubuf_append(it->key, it->query->rdata, it->query->len_rdata);
 
-	/* key: rrtype */
-	if (it->query->do_rrtype)
-		add_rrtype_to_key(it->key, it->query->rrtype);
-
 	it->m_iter = mtbl_source_get_prefix(it->source, ubuf_data(it->key), ubuf_size(it->key));
 	return dnstable_iter_init(query_iter_next, query_iter_free, it);
 }

--- a/dnstable/reader.c
+++ b/dnstable/reader.c
@@ -37,6 +37,12 @@ reader_iter_free(void *);
 static dnstable_res
 reader_iter_next(void *, struct dnstable_entry **);
 
+static int
+dnstable_dupsort_func(void *clos,
+		      const uint8_t *key, size_t len_key,
+		      const uint8_t *val0, size_t len_val0,
+		      const uint8_t *val1, size_t len_val1);
+
 struct dnstable_reader *
 dnstable_reader_init(const struct mtbl_source *source)
 {
@@ -45,6 +51,50 @@ dnstable_reader_init(const struct mtbl_source *source)
 	r->source = source;
 	return (r);
 }
+
+/*
+ * dnstable_dupsort_func is used to sort the entries with duplicate
+ * keys during the merge process based on their data.  The dnstable
+ * data is a triplet of variable-length integers, so (in theory) the
+ * byte comparison used for keys would not suffice.  This is mostly of
+ * interest with a NULL merge function, although it could be used to
+ * enforce some order of merges with a non-NULL merge function.
+ *
+ * This sorts first by time_first, then by time_last if time_first is the same.
+ */
+static int
+dnstable_dupsort_func(void *clos,
+		      const uint8_t *key, size_t len_key,
+		      const uint8_t *val0, size_t len_val0,
+		      const uint8_t *val1, size_t len_val1)
+{
+	uint64_t time_first0, time_last0, count0;
+	uint64_t time_first1, time_last1, count1;
+
+	if (len_key && (key[0] == ENTRY_TYPE_RRSET ||
+			key[0] == ENTRY_TYPE_RDATA))
+	{
+		assert(len_val0 && len_val1);
+		dnstable_res res;
+
+		res = triplet_unpack(val0, len_val0, &time_first0, &time_last0, &count0);
+		assert(res == dnstable_res_success);
+		res = triplet_unpack(val1, len_val1, &time_first1, &time_last1, &count1);
+		assert(res == dnstable_res_success);
+
+		if (time_first0 < time_first1)
+			return -1;
+		if (time_first0 > time_first1)
+			return 1;
+		if (time_last0 < time_last1)
+			return -1;
+		if (time_last0 > time_last1)
+			return 1;
+		return 0;
+	} else
+		return 0;
+}
+
 
 struct dnstable_reader *
 dnstable_reader_init_setfile(const char *setfile)
@@ -59,10 +109,13 @@ dnstable_reader_init_setfile(const char *setfile)
 	/* reset and redo the mtbl fileset options */
 	fopt = mtbl_fileset_options_init();
 	mtbl_fileset_options_set_merge_func(fopt, NULL, NULL);
+	mtbl_fileset_options_set_dupsort_func(fopt, dnstable_dupsort_func, NULL);
 	r->fs_no_merge = mtbl_fileset_dup(r->fs, fopt);
 	mtbl_fileset_options_destroy(&fopt);
+
 	r->source = mtbl_fileset_source(r->fs);
 	r->source_no_merge = mtbl_fileset_source(r->fs_no_merge);
+
 	return (r);
 }
 
@@ -116,9 +169,9 @@ dnstable_reader_iter_rdata_names(struct dnstable_reader *r)
 }
 
 /*
- * dnstable_reader_query returns aggregated
- * (e.g. a dnstable merge function is applied) or unaggregated results
- * depending upon the query object's aggregated flag.
+ * dnstable_reader_query returns aggregated (e.g. a dnstable merge
+ * function is applied) or unaggregated results depending upon the
+ * query object's aggregated flag.
  */
 struct dnstable_iter *
 dnstable_reader_query(struct dnstable_reader *r, struct dnstable_query *q)

--- a/man/dnstable_lookup.1
+++ b/man/dnstable_lookup.1
@@ -2,12 +2,12 @@
 .\"     Title: dnstable_lookup
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/31/2018
+.\"      Date: 03/28/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_LOOKUP" "1" "05/31/2018" "\ \&" "\ \&"
+.TH "DNSTABLE_LOOKUP" "1" "03/28/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,13 +31,13 @@
 dnstable_lookup \- lookup individual records in a dnstable data file or set of data files
 .SH "SYNOPSIS"
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] \fBrrset\fR <OWNER> [<RRTYPE> [<BAILIWICK>]]
+\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-u\fR] [\fB\-s #\fR] \fBrrset\fR <OWNER> [<RRTYPE> [<BAILIWICK>]]
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] \fBrdata ip\fR <ADDRESS | RANGE | PREFIX>
+\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-u\fR] [\fB\-s #\fR] \fBrdata ip\fR <ADDRESS | RANGE | PREFIX>
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] \fBrdata raw\fR <HEX STRING> [<RRTYPE>]
+\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-u\fR] [\fB\-s #\fR] \fBrdata raw\fR <HEX STRING> [<RRTYPE>]
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] \fBrdata name\fR <RDATA NAME> [<RRTYPE>]
+\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-u\fR] [\fB\-s #\fR] \fBrdata name\fR <RDATA NAME> [<RRTYPE>]
 .SH "DESCRIPTION"
 .sp
 Looks up records in a dnstable data file\&. Results are printed to stdout in an ad\-hoc text format\&.
@@ -54,6 +54,16 @@ Looks up records in a dnstable data file\&. Results are printed to stdout in an 
 \fB\-j\fR
 .RS 4
 Use JSON format for output\&. One JSON\-formatted entry per line will be printed\&.
+.RE
+.PP
+\fB\-u\fR
+.RS 4
+Output unaggregated results; default is aggregated results\&.
+.RE
+.PP
+\fB\-s #\fR
+.RS 4
+Skip the first # results\&.
 .RE
 .SH "ENVIRONMENT VARIABLES"
 .sp
@@ -82,7 +92,11 @@ $ dnstable_lookup rdata ip 198\&.51\&.100\&.0/24
 .sp
 $ dnstable_lookup rdata ip 203\&.0\&.113\&.1\-203\&.0\&.113\&.100
 .sp
-$ dnstable_lookup rdata ip 2001:db8::/32
+$ dnstable_lookup \-j rdata ip 2001:db8::/32
+.sp
+$ dnstable_lookup \-u rdata ip 2001:db8::/32
+.sp
+$ dnstable_lookup \-s 10 rdata ip 2001:db8::/32
 .sp
 $ dnstable_lookup rdata raw c00505f1
 .sp

--- a/man/dnstable_lookup.1.txt
+++ b/man/dnstable_lookup.1.txt
@@ -6,13 +6,13 @@ dnstable_lookup - lookup individual records in a dnstable data file or set of da
 
 == SYNOPSIS ==
 
-^dnstable_lookup^ [^-j^] ^rrset^ <OWNER> [<RRTYPE> [<BAILIWICK>]]
+^dnstable_lookup^ [^-j^] [^-u^] [^-s #^] ^rrset^ <OWNER> [<RRTYPE> [<BAILIWICK>]]
 
-^dnstable_lookup^ [^-j^] ^rdata ip^ <ADDRESS | RANGE | PREFIX>
+^dnstable_lookup^ [^-j^] [^-u^] [^-s #^] ^rdata ip^ <ADDRESS | RANGE | PREFIX>
 
-^dnstable_lookup^ [^-j^] ^rdata raw^ <HEX STRING> [<RRTYPE>]
+^dnstable_lookup^ [^-j^] [^-u^] [^-s #^] ^rdata raw^ <HEX STRING> [<RRTYPE>]
 
-^dnstable_lookup^ [^-j^] ^rdata name^ <RDATA NAME> [<RRTYPE>]
+^dnstable_lookup^ [^-j^] [^-u^] [^-s #^] ^rdata name^ <RDATA NAME> [<RRTYPE>]
 
 == DESCRIPTION ==
 
@@ -37,6 +37,13 @@ the specified domain name.
 ^-j^::
     Use JSON format for output. One JSON-formatted entry per line will be
     printed.
+
+^-u^::
+    Output unaggregated results; default is aggregated results.
+
+^-s #^::
+    Skip the first # results.
+
 
 == ENVIRONMENT VARIABLES ==
 
@@ -65,7 +72,11 @@ $ dnstable_lookup rdata ip 198.51.100.0/24
 
 $ dnstable_lookup rdata ip 203.0.113.1-203.0.113.100
 
-$ dnstable_lookup rdata ip 2001:db8::/32
+$ dnstable_lookup -j rdata ip 2001:db8::/32
+
+$ dnstable_lookup -u rdata ip 2001:db8::/32
+
+$ dnstable_lookup -s 10 rdata ip 2001:db8::/32
 
 $ dnstable_lookup rdata raw c00505f1
 

--- a/man/dnstable_query.3
+++ b/man/dnstable_query.3
@@ -2,12 +2,12 @@
 .\"     Title: dnstable_query
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/31/2018
+.\"      Date: 03/27/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_QUERY" "3" "05/31/2018" "\ \&" "\ \&"
+.TH "DNSTABLE_QUERY" "3" "03/27/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -71,6 +71,17 @@ dnstable_query_set_rrtype(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
 .sp
 .nf
 \fBdnstable_res
+dnstable_query_set_aggregated(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
+    bool \fR\fB\fIaggregated\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBbool
+dnstable_query_is_aggregated(const struct dnstable_query *\fR\fB\fIq\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBdnstable_res
 dnstable_query_set_bailiwick(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
     const char *\fR\fB\fIbailiwick\fR\fR\fB);\fR
 .fi
@@ -105,6 +116,10 @@ Once the query object has been constructed, \fBdnstable_query_iter\fR() iterates
 \fBdnstable_query_set_bailiwick\fR() is only valid for \fIDNSTABLE_QUERY_TYPE_RRSET\fR type queries\&. If set, it causes the bailiwick field of RRset entries to be filtered against the value provided\&.
 .sp
 \fBdnstable_query_set_rrtype\fR() and \fBdnstable_query_set_bailiwick\fR() are optional\&. If not called, no RRtype or bailiwick filtering will be performed\&.
+.sp
+\fBdnstable_query_set_aggregated\fR() sets if the results from queries should be aggregated or not\&. The default is \fITrue\fR == aggregated\&.
+.sp
+\fBdnstable_query_is_aggregated\fR() returns the aggregated setting for this query\&. The default is \fITrue\fR == aggregated\&.
 .sp
 \fBdnstable_query_set_data\fR() specifies the main search parameter and is required\&. Its meaning depends on the query type\&.
 .sp

--- a/man/dnstable_query.3
+++ b/man/dnstable_query.3
@@ -71,6 +71,12 @@ dnstable_query_set_rrtype(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
 .sp
 .nf
 \fBdnstable_res
+dnstable_query_set_skip(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
+    uint64_t \fR\fB\fIskip\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBdnstable_res
 dnstable_query_set_aggregated(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
     bool \fR\fB\fIaggregated\fR\fR\fB);\fR
 .fi
@@ -111,6 +117,8 @@ Once the query object has been constructed, \fBdnstable_query_iter\fR() iterates
 \fBdnstable_query_set_bailiwick\fR() is only valid for \fIDNSTABLE_QUERY_TYPE_RRSET\fR type queries\&. If set, it causes the bailiwick field of RRset entries to be filtered against the value provided\&.
 .sp
 \fBdnstable_query_set_rrtype\fR() and \fBdnstable_query_set_bailiwick\fR() are optional\&. If not called, no RRtype or bailiwick filtering will be performed\&.
+.sp
+\fBdnstable_query_set_skip()\fR sets the number of initial rows to skip from the results\&. The default is 0, which means to not skip any rows\&.
 .sp
 \fBdnstable_query_set_aggregated\fR() sets if the results from queries should be aggregated\&. The default is \fItrue\fR for aggregated results\&.
 .sp

--- a/man/dnstable_query.3
+++ b/man/dnstable_query.3
@@ -2,12 +2,12 @@
 .\"     Title: dnstable_query
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 03/27/2019
+.\"      Date: 03/28/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_QUERY" "3" "03/27/2019" "\ \&" "\ \&"
+.TH "DNSTABLE_QUERY" "3" "03/28/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -76,11 +76,6 @@ dnstable_query_set_aggregated(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
 .fi
 .sp
 .nf
-\fBbool
-dnstable_query_is_aggregated(const struct dnstable_query *\fR\fB\fIq\fR\fR\fB);\fR
-.fi
-.sp
-.nf
 \fBdnstable_res
 dnstable_query_set_bailiwick(struct dnstable_query *\fR\fB\fIq\fR\fR\fB,
     const char *\fR\fB\fIbailiwick\fR\fR\fB);\fR
@@ -118,8 +113,6 @@ Once the query object has been constructed, \fBdnstable_query_iter\fR() iterates
 \fBdnstable_query_set_rrtype\fR() and \fBdnstable_query_set_bailiwick\fR() are optional\&. If not called, no RRtype or bailiwick filtering will be performed\&.
 .sp
 \fBdnstable_query_set_aggregated\fR() sets if the results from queries should be aggregated or not\&. The default is \fITrue\fR == aggregated\&.
-.sp
-\fBdnstable_query_is_aggregated\fR() returns the aggregated setting for this query\&. The default is \fITrue\fR == aggregated\&.
 .sp
 \fBdnstable_query_set_data\fR() specifies the main search parameter and is required\&. Its meaning depends on the query type\&.
 .sp

--- a/man/dnstable_query.3
+++ b/man/dnstable_query.3
@@ -112,7 +112,7 @@ Once the query object has been constructed, \fBdnstable_query_iter\fR() iterates
 .sp
 \fBdnstable_query_set_rrtype\fR() and \fBdnstable_query_set_bailiwick\fR() are optional\&. If not called, no RRtype or bailiwick filtering will be performed\&.
 .sp
-\fBdnstable_query_set_aggregated\fR() sets if the results from queries should be aggregated or not\&. The default is \fITrue\fR == aggregated\&.
+\fBdnstable_query_set_aggregated\fR() sets if the results from queries should be aggregated\&. The default is \fItrue\fR for aggregated results\&.
 .sp
 \fBdnstable_query_set_data\fR() specifies the main search parameter and is required\&. Its meaning depends on the query type\&.
 .sp

--- a/man/dnstable_query.3.txt
+++ b/man/dnstable_query.3.txt
@@ -44,10 +44,6 @@ dnstable_query_set_aggregated(struct dnstable_query *'q',
     bool 'aggregated');^
 
 [verse]
-^bool
-dnstable_query_is_aggregated(const struct dnstable_query *'q');^
-
-[verse]
 ^dnstable_res
 dnstable_query_set_bailiwick(struct dnstable_query *'q',
     const char *'bailiwick');^
@@ -102,8 +98,6 @@ filtered against the value provided.
 If not called, no RRtype or bailiwick filtering will be performed.
 
 ^dnstable_query_set_aggregated^() sets if the results from queries should be aggregated or not.  The default is _True_ == aggregated.
-
-^dnstable_query_is_aggregated^() returns the aggregated setting for this query.  The default is _True_ == aggregated.
 
 ^dnstable_query_set_data^() specifies the main search parameter and is required.
 Its meaning depends on the query type.

--- a/man/dnstable_query.3.txt
+++ b/man/dnstable_query.3.txt
@@ -97,7 +97,8 @@ filtered against the value provided.
 ^dnstable_query_set_rrtype^() and ^dnstable_query_set_bailiwick^() are optional.
 If not called, no RRtype or bailiwick filtering will be performed.
 
-^dnstable_query_set_aggregated^() sets if the results from queries should be aggregated or not.  The default is _True_ == aggregated.
+^dnstable_query_set_aggregated^() sets if the results from queries should be
+aggregated. The default is _true_ for aggregated results.
 
 ^dnstable_query_set_data^() specifies the main search parameter and is required.
 Its meaning depends on the query type.

--- a/man/dnstable_query.3.txt
+++ b/man/dnstable_query.3.txt
@@ -40,6 +40,15 @@ dnstable_query_set_rrtype(struct dnstable_query *'q',
 
 [verse]
 ^dnstable_res
+dnstable_query_set_aggregated(struct dnstable_query *'q',
+    bool 'aggregated');^
+
+[verse]
+^bool
+dnstable_query_is_aggregated(const struct dnstable_query *'q');^
+
+[verse]
+^dnstable_res
 dnstable_query_set_bailiwick(struct dnstable_query *'q',
     const char *'bailiwick');^
 
@@ -91,6 +100,10 @@ filtered against the value provided.
 
 ^dnstable_query_set_rrtype^() and ^dnstable_query_set_bailiwick^() are optional.
 If not called, no RRtype or bailiwick filtering will be performed.
+
+^dnstable_query_set_aggregated^() sets if the results from queries should be aggregated or not.  The default is _True_ == aggregated.
+
+^dnstable_query_is_aggregated^() returns the aggregated setting for this query.  The default is _True_ == aggregated.
 
 ^dnstable_query_set_data^() specifies the main search parameter and is required.
 Its meaning depends on the query type.

--- a/man/dnstable_query.3.txt
+++ b/man/dnstable_query.3.txt
@@ -40,6 +40,11 @@ dnstable_query_set_rrtype(struct dnstable_query *'q',
 
 [verse]
 ^dnstable_res
+dnstable_query_set_skip(struct dnstable_query *'q',
+    uint64_t 'skip');^
+
+[verse]
+^dnstable_res
 dnstable_query_set_aggregated(struct dnstable_query *'q',
     bool 'aggregated');^
 
@@ -96,6 +101,9 @@ filtered against the value provided.
 
 ^dnstable_query_set_rrtype^() and ^dnstable_query_set_bailiwick^() are optional.
 If not called, no RRtype or bailiwick filtering will be performed.
+
+^dnstable_query_set_skip()^ sets the number of initial rows to skip
+from the results.  The default is 0, which means to not skip any rows.
 
 ^dnstable_query_set_aggregated^() sets if the results from queries should be
 aggregated. The default is _true_ for aggregated results.

--- a/man/dnstable_reader.3
+++ b/man/dnstable_reader.3
@@ -72,6 +72,11 @@ dnstable_reader_iter_rdata(struct dnstable_reader *\fR\fB\fIr\fR\fR\fB);\fR
 \fBstruct dnstable_iter *
 dnstable_reader_query(struct dnstable_reader *\fR\fB\fIr\fR\fR\fB, struct dnstable_query *\fR\fB\fIq\fR\fR\fB);\fR
 .fi
+.sp
+.nf
+\fBstruct dnstable_iter *
+dnstable_reader_query_no_aggregate(struct dnstable_reader *\fR\fB\fIr\fR\fR\fB, struct dnstable_query *\fR\fB\fIq\fR\fR\fB);\fR
+.fi
 .SH "DESCRIPTION"
 .sp
 \fBdnstable_reader\fR is the high\-level interface for reading dnstable entries from a dnstable data source\&. Results are returned through the \fBdnstable_iter\fR interface\&.
@@ -85,6 +90,8 @@ dnstable_reader_query(struct dnstable_reader *\fR\fB\fIr\fR\fR\fB, struct dnstab
 \fBdnstable_reader_iter_rrset\fR() iterates over just the entries of type \fIDNSTABLE_ENTRY_TYPE_RRSET\fR\&. Likewise, \fBdnstable_reader_iter_rdata\fR() iterates over just the entries of type \fIDNSTABLE_ENTRY_TYPE_RDATA\fR\&.
 .sp
 \fBdnstable_reader_query\fR() iterates over all the entry objects that match the specified query object\&.
+.sp
+\fBdnstable_reader_query_no_aggregate\fR() iterates over all the entry objects that match the specified query object, but does not call a merge function to aggregate values\&.
 .SH "SEE ALSO"
 .sp
 \fBdnstable_iter\fR(3), \fBdnstable_query\fR(3), \fBmtbl_source\fR(3)

--- a/tests/test-dns.setfile
+++ b/tests/test-dns.setfile
@@ -1,0 +1,2 @@
+test-dns.mtbl
+test-dns.mtbl

--- a/tests/tests.sh.in
+++ b/tests/tests.sh.in
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 DNSTQ=@abs_top_builddir@/src/dnstable_lookup
+unset DNSTABLE_SETFILE
 export DNSTABLE_FNAME=@abs_top_srcdir@/tests/test-dns.mtbl
 
 #
@@ -111,6 +112,16 @@ EOF
 
 test_lookup rdata raw 00 MX << EOF
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
+EOF
+
+export DNSTABLE_SETFILE=@abs_top_srcdir@/tests/test-dns.setfile
+unset DNSTABLE_FNAME
+
+test_lookup -u rdata raw 00 MX << EOF
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
 EOF
 

--- a/tests/tests.sh.in
+++ b/tests/tests.sh.in
@@ -105,4 +105,13 @@ test_lookup rdata name ldap.example.com << EOF
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"_ldap._tcp.example.com.","rrtype":"SRV","rdata":"10 1 389 ldap.example.com."}
 EOF
 
+test_lookup rdata raw 00 SRV << EOF
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"_ldap._tcp.example.com.","rrtype":"SRV","rdata":"10 1 389 ldap.example.com."}
+EOF
+
+test_lookup rdata raw 00 MX << EOF
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
+EOF
+
 exit $code

--- a/tests/tests.sh.in
+++ b/tests/tests.sh.in
@@ -115,12 +115,21 @@ test_lookup rdata raw 00 MX << EOF
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
 EOF
 
+test_lookup -s 1 rdata raw 00 MX << EOF
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
+EOF
+
 export DNSTABLE_SETFILE=@abs_top_srcdir@/tests/test-dns.setfile
 unset DNSTABLE_FNAME
 
 test_lookup -u rdata raw 00 MX << EOF
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"10 mail.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
+{"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
+EOF
+
+test_lookup -s 2 -u rdata raw 00 MX << EOF
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
 {"count":1,"time_first":1522147408,"time_last":1522147408,"rrname":"example.com.","rrtype":"MX","rdata":"20 mail2.example.com."}
 EOF


### PR DESCRIPTION
Also document the aggregate flag in dnstable_lookup command line tool