### PR TITLE
don't use libtool current/interface version for the merge dso

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,8 @@ EXTRA_DIST += src/dnstable_merge.sh.in
 bin_SCRIPTS = src/dnstable_merge
 CLEANFILES += $(bin_SCRIPTS)
 src/dnstable_merge:
-	sed -e "s/@LIBDNSTABLE_CURRENT@/$(LIBDNSTABLE_CURRENT)/" ${srcdir}/src/dnstable_merge.sh.in >$@
+	dlname=`sed -n "s/^dlname='\(.*\)'/\1/p" dnstable/libdnstable.la` ; \
+	sed -e "s/@LIBDNSTABLE_DLNAME@/$$dlname/" ${srcdir}/src/dnstable_merge.sh.in >$@
 	chmod +x $@
 
 pkgconfig_DATA = dnstable/libdnstable.pc

--- a/src/dnstable_merge.sh.in
+++ b/src/dnstable_merge.sh.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-export MTBL_MERGE_DSO="libdnstable.so.@LIBDNSTABLE_CURRENT@"
+export MTBL_MERGE_DSO="@LIBDNSTABLE_DLNAME@"
 export MTBL_MERGE_FUNC_PREFIX="dnstable_merge"
 
 if [ -z "$1" -o -z "$2" ]; then


### PR DESCRIPTION
Just get and use the dlname as defined by libtool in the .la file.

(Don't default like it is sco or sunos where the major number is
the current interface number.  For example on Linux, the major
number is current minus age.)

This fixes my mistake. With current bump the DSO file was not found because 1 didn't match 0.