### PR TITLE
Dump hex raw

### DIFF
--- a/dnstable/dnstable.h
+++ b/dnstable/dnstable.h
@@ -220,6 +220,12 @@ void
 dnstable_formatter_set_rdata_array(
    struct dnstable_formatter *f, bool always_array);
 
+/* If add_raw_rdata is true, the returned JSON objects will contain an
+   additional raw_rdata field.  Default is false. */
+void
+dnstable_formatter_set_add_raw_rdata(
+   struct dnstable_formatter *f, bool add_raw_rdata);
+
 /* Returns dynamically allocated string with the entry rendered in json format */
 char *
 dnstable_entry_format(

--- a/dnstable/libdnstable.sym
+++ b/dnstable/libdnstable.sym
@@ -66,3 +66,9 @@ global:
         dnstable_query_set_aggregated;
         dnstable_query_set_offset;
 } LIBDNSTABLE_0.9.0;
+
+LIBDNSTABLE_0.12.0 {
+global:
+        dnstable_formatter_set_add_raw_rdata;
+} LIBDNSTABLE_0.11.0;
+

--- a/man/dnstable_dump.1
+++ b/man/dnstable_dump.1
@@ -2,12 +2,12 @@
 .\"     Title: dnstable_dump
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 05/31/2018
+.\"      Date: 05/08/2020
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_DUMP" "1" "05/31/2018" "\ \&" "\ \&"
+.TH "DNSTABLE_DUMP" "1" "05/08/2020" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,13 +31,18 @@
 dnstable_dump \- dump dnstable data file to text or JSON
 .SH "SYNOPSIS"
 .sp
-\fBdnstable_dump\fR [\fB\-\-json\fR] \fB\-\-rrset\fR \fIfilename\fR
+\fBdnstable_dump\fR [\fB\-\-raw\fR] [\fB\-\-json\fR] \fB\-\-rrset\fR \fIfilename\fR
 .sp
-\fBdnstable_dump\fR [\fB\-\-json\fR] \fB\-\-rdata\fR \fIfilename\fR
+\fBdnstable_dump\fR [\fB\-\-raw\fR] [\fB\-\-json\fR] \fB\-\-rdata\fR \fIfilename\fR
 .SH "DESCRIPTION"
 .sp
 Dumps a dnstable data file to stdout, either in an ad\-hoc text format (the default), or in JSON format\&. Specifying one of \fB\-\-rrset\fR or \fB\-\-rdata\fR is required in order to select which section of the data file to dump\&.
 .SH "OPTIONS"
+.PP
+\fB\-R\fR, \fB\-\-raw\fR
+.RS 4
+When using JSON format for output, add a hex representation of the raw rdata\&.
+.RE
 .PP
 \fB\-j\fR, \fB\-\-json\fR
 .RS 4
@@ -57,3 +62,8 @@ Dump the
 \fBRdata\fR
 section of the data file\&.
 .RE
+.SH "EXAMPLES"
+.sp
+$ dnstable_dump \-R \-j \-d /path/to/dns\&.mtbl
+.sp
+$ dnstable_dump \-r /path/to/dns\&.mtbl

--- a/man/dnstable_dump.1.txt
+++ b/man/dnstable_dump.1.txt
@@ -6,9 +6,9 @@ dnstable_dump - dump dnstable data file to text or JSON
 
 == SYNOPSIS ==
 
-^dnstable_dump^ [^--json^] ^--rrset^ 'filename'
+^dnstable_dump^ [^--raw^] [^--json^] ^--rrset^ 'filename'
 
-^dnstable_dump^ [^--json^] ^--rdata^ 'filename'
+^dnstable_dump^ [^--raw^] [^--json^] ^--rdata^ 'filename'
 
 == DESCRIPTION ==
 
@@ -17,6 +17,10 @@ default), or in JSON format. Specifying one of ^--rrset^ or ^--rdata^ is
 required in order to select which section of the data file to dump.
 
 == OPTIONS ==
+
+^-R^, ^--raw^::
+    When using JSON format for output, add a hex representation of the
+    raw rdata.
 
 ^-j^, ^--json^::
     Use JSON format for output. One JSON-formatted entry per line will be
@@ -27,3 +31,12 @@ required in order to select which section of the data file to dump.
 
 ^-d^, ^--rdata^::
     Dump the ^Rdata^ section of the data file.
+
+== EXAMPLES ==
+
+$ dnstable_dump -R -j -d /path/to/dns.mtbl
+
+$ dnstable_dump -r /path/to/dns.mtbl
+
+
+

--- a/man/dnstable_lookup.1
+++ b/man/dnstable_lookup.1
@@ -2,12 +2,12 @@
 .\"     Title: dnstable_lookup
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 06/14/2019
+.\"      Date: 05/08/2020
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_LOOKUP" "1" "06/14/2019" "\ \&" "\ \&"
+.TH "DNSTABLE_LOOKUP" "1" "05/08/2020" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,13 +31,13 @@
 dnstable_lookup \- lookup individual records in a dnstable data file or set of data files
 .SH "SYNOPSIS"
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrrset\fR <OWNER> [<RRTYPE> [<BAILIWICK>]]
+\fBdnstable_lookup\fR [\fB\-R\fR] [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrrset\fR <OWNER> [<RRTYPE> [<BAILIWICK>]]
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrdata ip\fR <ADDRESS | RANGE | PREFIX>
+\fBdnstable_lookup\fR [\fB\-R\fR] [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrdata ip\fR <ADDRESS | RANGE | PREFIX>
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrdata raw\fR <HEX STRING> [<RRTYPE>]
+\fBdnstable_lookup\fR [\fB\-R\fR] [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrdata raw\fR <HEX STRING> [<RRTYPE>]
 .sp
-\fBdnstable_lookup\fR [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrdata name\fR <RDATA NAME> [<RRTYPE>]
+\fBdnstable_lookup\fR [\fB\-R\fR] [\fB\-j\fR] [\fB\-J\fR] [\fB\-u\fR] [\fB\-O #\fR] \fBrdata name\fR <RDATA NAME> [<RRTYPE>]
 .SH "DESCRIPTION"
 .sp
 Looks up records in a dnstable data file\&. Results are printed to stdout in an ad\-hoc text format\&.
@@ -50,6 +50,11 @@ Looks up records in a dnstable data file\&. Results are printed to stdout in an 
 .sp
 \fBdnstable_lookup rdata name\fR returns Resource Records whose record data matches the specified domain name\&.
 .SH "OPTIONS"
+.PP
+\fB\-R\fR, \fB\-\-raw\fR
+.RS 4
+When using JSON format for output, add a hex representation of the raw rdata\&.
+.RE
 .PP
 \fB\-j\fR
 .RS 4
@@ -102,6 +107,8 @@ $ dnstable_lookup rdata ip 198\&.51\&.100\&.0/24
 $ dnstable_lookup rdata ip 203\&.0\&.113\&.1\-203\&.0\&.113\&.100
 .sp
 $ dnstable_lookup \-j rdata ip 2001:db8::/32
+.sp
+$ dnstable_lookup \-R \-j rdata ip 2001:db8::/32
 .sp
 $ dnstable_lookup \-u rdata ip 2001:db8::/32
 .sp

--- a/man/dnstable_lookup.1.txt
+++ b/man/dnstable_lookup.1.txt
@@ -6,13 +6,13 @@ dnstable_lookup - lookup individual records in a dnstable data file or set of da
 
 == SYNOPSIS ==
 
-^dnstable_lookup^ [^-j^] [^-J^] [^-u^] [^-O #^] ^rrset^ <OWNER> [<RRTYPE> [<BAILIWICK>]]
+^dnstable_lookup^ [^-R^] [^-j^] [^-J^] [^-u^] [^-O #^] ^rrset^ <OWNER> [<RRTYPE> [<BAILIWICK>]]
 
-^dnstable_lookup^ [^-j^] [^-J^] [^-u^] [^-O #^] ^rdata ip^ <ADDRESS | RANGE | PREFIX>
+^dnstable_lookup^ [^-R^] [^-j^] [^-J^] [^-u^] [^-O #^] ^rdata ip^ <ADDRESS | RANGE | PREFIX>
 
-^dnstable_lookup^ [^-j^] [^-J^] [^-u^] [^-O #^] ^rdata raw^ <HEX STRING> [<RRTYPE>]
+^dnstable_lookup^ [^-R^] [^-j^] [^-J^] [^-u^] [^-O #^] ^rdata raw^ <HEX STRING> [<RRTYPE>]
 
-^dnstable_lookup^ [^-j^] [^-J^] [^-u^] [^-O #^] ^rdata name^ <RDATA NAME> [<RRTYPE>]
+^dnstable_lookup^ [^-R^] [^-j^] [^-J^] [^-u^] [^-O #^] ^rdata name^ <RDATA NAME> [<RRTYPE>]
 
 == DESCRIPTION ==
 
@@ -33,6 +33,10 @@ the specified data value, expressed as a hexademical string.
 the specified domain name.
 
 == OPTIONS ==
+
+^-R^, ^--raw^::
+    When using JSON format for output, add a hex representation of the
+    raw rdata.
 
 ^-j^::
     Use JSON format for output, with timestamps in epoch time (seconds since epoch).
@@ -79,6 +83,8 @@ $ dnstable_lookup rdata ip 198.51.100.0/24
 $ dnstable_lookup rdata ip 203.0.113.1-203.0.113.100
 
 $ dnstable_lookup -j rdata ip 2001:db8::/32
+
+$ dnstable_lookup -R -j rdata ip 2001:db8::/32
 
 $ dnstable_lookup -u rdata ip 2001:db8::/32
 

--- a/src/dnstable_lookup.c
+++ b/src/dnstable_lookup.c
@@ -27,24 +27,27 @@
 #include <dnstable.h>
 #include <mtbl.h>
 
-bool g_json = false;
-bool g_Json = false;
-bool g_aggregate = true;
-int64_t g_offset = 0;
+static bool g_json = false;
+static bool g_Json = false;
+static bool g_add_raw;
+static bool g_aggregate = true;
+static int64_t g_offset = 0;
 
 static void
 print_entry(struct dnstable_entry *ent)
 {
 	char *s;
 
-	if (g_Json) {
+	if (g_Json || g_json) {
 		struct dnstable_formatter *fmt = dnstable_formatter_init();
 		dnstable_formatter_set_output_format(fmt, dnstable_output_format_json);
-		dnstable_formatter_set_date_format(fmt, dnstable_date_format_rfc3339);
+                if (g_json)
+                        dnstable_formatter_set_date_format(fmt, dnstable_date_format_unix);
+                else
+                        dnstable_formatter_set_date_format(fmt, dnstable_date_format_rfc3339);
+		dnstable_formatter_set_add_raw_rdata(fmt, g_add_raw);
 		s = dnstable_entry_format(fmt, ent);
 		dnstable_formatter_destroy(&fmt);
-	} else if (g_json) {
-		s = dnstable_entry_to_json(ent);
 	} else {
 		s = dnstable_entry_to_text(ent);
 	}
@@ -78,14 +81,15 @@ static void
 usage(void)
 {
 	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-u] [-s #] rrset <OWNER NAME> [<RRTYPE> [<BAILIWICK>]]\n");
-	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-u] [-s #] rdata ip <ADDRESS | RANGE | PREFIX>\n");
-	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-u] [-s #] rdata raw <HEX STRING> [<RRTYPE>]\n");
-	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-u] [-s #] rdata name <RDATA NAME> [<RRTYPE>]\n");
+	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-R] [-u] [-s #] rrset <OWNER NAME> [<RRTYPE> [<BAILIWICK>]]\n");
+	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-R] [-u] [-s #] rdata ip <ADDRESS | RANGE | PREFIX>\n");
+	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-R] [-u] [-s #] rdata raw <HEX STRING> [<RRTYPE>]\n");
+	fprintf(stderr, "\tdnstable_lookup [-j] [-J] [-R] [-u] [-s #] rdata name <RDATA NAME> [<RRTYPE>]\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Flags:\n");
 	fprintf(stderr, "\t-j: output in JSON format with epoch time; default is 'dig' presentation format\n");
 	fprintf(stderr, "\t-J: output in JSON format with human time (RFC3339 format); default is 'dig' presentation format\n");
+	fprintf(stderr, "\t-R: add raw rdata representation\n");
 	fprintf(stderr, "\t-u: output unaggregated results; default is aggregated results\n");
 	fprintf(stderr, "\t-O #: offset the first # results (must be a positive number)\n");
 	exit(EXIT_FAILURE);
@@ -110,13 +114,16 @@ main(int argc, char **argv)
 	dnstable_res res;
 	int ch;
 
-	while ((ch = getopt(argc, argv, "jJuO:")) != -1) {
+	while ((ch = getopt(argc, argv, "jJRuO:")) != -1) {
 	        switch (ch) {
 	        case 'j':
 	                g_json = true;
 	                break;
 	        case 'J':
 	                g_Json = true;
+	                break;
+	        case 'R':
+	                g_add_raw = true;
 	                break;
 	        case 'u':
 	                g_aggregate = false;
@@ -178,6 +185,10 @@ main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
+        if (!g_json && g_add_raw) {
+                fprintf(stderr, "dnstable_lookup: adding raw rdata only supported with -j json output format\n");
+		exit(EXIT_FAILURE);
+        }
 	env_fname = getenv("DNSTABLE_FNAME");
 	env_setfile = getenv("DNSTABLE_SETFILE");
 	if ((!env_fname && !env_setfile) || (env_fname && env_setfile)) {


### PR DESCRIPTION
Add -R flag to support for adding raw rdata representation to outputs from dnstable_lookup and dnstable_dump.

The work is *not* finished yet.  Need to update the man pages.  Need to update debian control files.