### PR TITLE
Fix small memory leaks

### DIFF
--- a/dnstable/entry.c
+++ b/dnstable/entry.c
@@ -397,6 +397,7 @@ dnstable_entry_to_json_fmt(const struct dnstable_entry *e,
 				fmt_hex_str(rbuf, (char*)rrtype, rrtype_str_len);
 				ubuf_cterm(rbuf);
 				ubuf_detach(rbuf, &rbuf_as_str, &rbuf_as_str_len);
+				ubuf_destroy(&rbuf);
 				add_yajl_string(g, (char*)rbuf_as_str);
 				my_free(rbuf_as_str);
 			}
@@ -443,6 +444,7 @@ dnstable_entry_to_json_fmt(const struct dnstable_entry *e,
 			fmt_hex_str(rbuf, (char*)rdata->data, rdata->len);
 			ubuf_cterm(rbuf);
 			ubuf_detach(rbuf, &rbuf_as_str, &rbuf_as_str_len);
+			ubuf_destroy(&rbuf);
 			add_yajl_string(g, (char*)rbuf_as_str);
 			my_free(rbuf_as_str);
 


### PR DESCRIPTION
valgrind noticed leaks from
`dnstable_dump -r -j -R tests/test-dns.mtbl`
and
`dnstable_dump -d -j -R tests/test-dns.mtbl`