### PR TITLE
Update dnstable-bin mtbl-bin dependency to take advantage of new comm…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dnstable (0.12.0-2) debian-fsi; urgency=medium
+
+  * Update dnstable-bin dependency to depend on latest mtbl-bin.
+
+ -- Farsight Security, Inc. <software@farsightsecurity.com>  Wed, 03 Nov 2021 23:06:41 +0000
+
 dnstable (0.12.0-1) debian-fsi; urgency=medium
 
   * Implement indexing using RRtypes for ENTRY_TYPE_RRSET_NAME_FWD

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  dh-autoreconf (>= 5~),
  dpkg-dev (>= 1.16.0~),
  lcov,
- libmtbl-dev (>= 1.3.0),
+ libmtbl-dev (>= 1.4.0),
  libwdns-dev (>= 0.6.0),
  libyajl-dev (>= 1.0.8),
  mtbl-bin,
@@ -19,7 +19,7 @@ Standards-Version: 3.9.8
 Package: dnstable-bin
 Section: utils
 Architecture: any
-Depends: mtbl-bin, ${misc:Depends}, ${shlibs:Depends}
+Depends: mtbl-bin (>= 1.4.0), ${misc:Depends}, ${shlibs:Depends}
 Description: passive DNS encoding format library (utilities)
  dnstable implements an encoding format for passive DNS data. It consists of a
  C library, libdnstable, and command line utilities for creating, querying,


### PR DESCRIPTION
…and-line options.

We're already wanting to use those useful options in e.g. dnstable_merge, which simply calls mtbl_merge, this debian-bump release will enable us to make that dependency explicit.