### PR TITLE
Update rdata name type list

### DIFF
--- a/dnstable/query.c
+++ b/dnstable/query.c
@@ -456,6 +456,8 @@ dnstable_query_filter(struct dnstable_query *q, struct dnstable_entry *e, bool *
 		case WDNS_TYPE_SVCB:
 		case WDNS_TYPE_HTTPS:
 		case WDNS_TYPE_NSEC:
+		case WDNS_TYPE_RP:
+		case WDNS_TYPE_NXT:
 			break;
 		default:
 			goto fail;

--- a/dnstable/query.c
+++ b/dnstable/query.c
@@ -455,6 +455,7 @@ dnstable_query_filter(struct dnstable_query *q, struct dnstable_entry *e, bool *
 		case WDNS_TYPE_SRV:
 		case WDNS_TYPE_SVCB:
 		case WDNS_TYPE_HTTPS:
+		case WDNS_TYPE_NSEC:
 			break;
 		default:
 			goto fail;


### PR DESCRIPTION
Add missing NSEC, along with RP and NXT to include all wdns-supported types beginning with a name, plus MX and SRV, leaving out the deprecated pre-MX mail routing records.