### PR TITLE
Build shared library on cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,7 @@ dnstable_libdnstable_la_LIBADD = \
 	$(libwdns_LIBS) \
 	$(libyajl_LIBS)
 dnstable_libdnstable_la_LDFLAGS = $(AM_LDFLAGS) \
+	-no-undefined \
 	-version-info $(LIBDNSTABLE_CURRENT):$(LIBDNSTABLE_REVISION):$(LIBDNSTABLE_AGE)
 if HAVE_LD_VERSION_SCRIPT
 dnstable_libdnstable_la_LDFLAGS += \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.0-1.x86_64 2024-02-01 11:02 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/farsightsec/dnstable.git
$ cd dnstable
$ ./autogen.sh
$ ./configure --enable-shared --disable-static
$ make V=1
: 
/bin/sh ./libtool  --tag=CC   --mode=link gcc -Wall -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wpointer-arith -Wsign-compare -Wchar-subscripts -Wstrict-prototypes -Wshadow -Wformat-security    -g -O2   -version-info 2:3:2 -Wl,--version-script=./dnstable/libdnstable.sym   -o dnstable/libdnstable.la -rpath /usr/local/lib dnstable/entry.lo dnstable/iter.lo dnstable/merge.lo dnstable/query.lo dnstable/reader.lo dnstable/triplet.lo libmy/my_format.lo -lmtbl -lwdns -lyajl
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!